### PR TITLE
Add Java logging configuration.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 COPY --from=0 /buildfarm-server_deploy.jar /buildfarm-worker_deploy.jar /
-COPY server/server.config worker/worker.config /config/
+COPY logging.properties server/server.config worker/worker.config /config/

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,4 +2,4 @@ build:
   docker:
     worker: worker/Dockerfile
 run:
-  worker: java -jar /buildfarm-worker_deploy.jar /config/worker.config
+  worker: java -Djava.util.logging.config.file=/config/logging.properties -jar /buildfarm-worker_deploy.jar /config/worker.config

--- a/logging.properties
+++ b/logging.properties
@@ -1,0 +1,4 @@
+handlers = java.util.logging.ConsoleHandler
+
+java.util.logging.ConsoleHandler.level     = ALL
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,3 +1,4 @@
 FROM toxchat/buildfarm
 
-CMD java -jar /buildfarm-server_deploy.jar /config/server.config
+COPY server.config /config/
+CMD java -Djava.util.logging.config.file=/config/logging.properties -jar /buildfarm-server_deploy.jar /config/server.config

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,3 +1,4 @@
 FROM toxchat/buildfarm
 
-CMD java -jar /buildfarm-worker_deploy.jar /config/worker.config
+COPY worker.config /config/
+CMD java -Djava.util.logging.config.file=/config/logging.properties -jar /buildfarm-worker_deploy.jar /config/worker.config


### PR DESCRIPTION
Nothing actually logs anything, so we don't see anything, but if
buildfarm adds logging, we'll get it in the heroku logs.